### PR TITLE
add nginx syntax highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ _Repeat this section for all languages_
 - [ ] Is the server being monitored by our server-monitor?
 - [ ] Do urls with `index.php` get redirected?
 
-```
+```nginx
 if ($request_uri ~* "^(.*/)index\.php/?(.*)") {
     return 301 "$1$2";
 }


### PR DESCRIPTION
I didn't read properly the last time and just assumed that it was PHP code. Turns out that the github flavor of markdown supports nginx. I don't mean to be spamming you guys with pull-requests, sorry for that.